### PR TITLE
Add password confirmation and validation

### DIFF
--- a/frontend/js/cambiar-contrasena.js
+++ b/frontend/js/cambiar-contrasena.js
@@ -1,10 +1,29 @@
 const btn = document.getElementById('changeBtn');
 const messageDiv = document.getElementById('changeMessage');
+const newPasswordInput = document.getElementById('newPassword');
+const confirmPasswordInput = document.getElementById('confirmPassword');
+const toggleNewPassword = document.getElementById('toggleNewPassword');
+const toggleConfirmPassword = document.getElementById('toggleConfirmPassword');
+const eyeOpen = '../public/assets/img/ojo-abierto.png';
+const eyeClosed = '../public/assets/img/ojo.png';
 
 btn.addEventListener('click', async () => {
-    const newPassword = document.getElementById('newPassword').value.trim();
-    if (!newPassword) {
-        showMessage('Debe ingresar una nueva contraseña', 'error');
+    const newPassword = newPasswordInput.value.trim();
+    const confirmPassword = confirmPasswordInput.value.trim();
+
+    if (!newPassword || !confirmPassword) {
+        showMessage('Debe completar ambos campos', 'error');
+        return;
+    }
+
+    const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    if (!passwordRegex.test(newPassword)) {
+        showMessage('La contraseña debe tener al menos 8 caracteres, una mayúscula, un número y un caracter especial', 'error');
+        return;
+    }
+
+    if (newPassword !== confirmPassword) {
+        showMessage('Las contraseñas no coinciden', 'error');
         return;
     }
 
@@ -34,3 +53,17 @@ function showMessage(msg, type) {
     messageDiv.textContent = msg;
     messageDiv.className = `message ${type}`;
 }
+
+// Toggle para mostrar/ocultar la nueva contraseña
+toggleNewPassword.addEventListener('click', () => {
+    const isVisible = newPasswordInput.type === 'text';
+    newPasswordInput.type = isVisible ? 'password' : 'text';
+    toggleNewPassword.querySelector('img').src = isVisible ? eyeClosed : eyeOpen;
+});
+
+// Toggle para mostrar/ocultar la confirmación
+toggleConfirmPassword.addEventListener('click', () => {
+    const isVisible = confirmPasswordInput.type === 'text';
+    confirmPasswordInput.type = isVisible ? 'password' : 'text';
+    toggleConfirmPassword.querySelector('img').src = isVisible ? eyeClosed : eyeOpen;
+});

--- a/frontend/views/cambiar-contrasena.html
+++ b/frontend/views/cambiar-contrasena.html
@@ -19,7 +19,19 @@
         <label for="newPassword">Nueva contraseña</label>
         <div class="password-wrapper">
           <input type="password" id="newPassword" placeholder="Nueva contraseña" required />
+          <span class="toggle-password" id="toggleNewPassword">
+            <img src="../public/assets/img/ojo.png" alt="Mostrar contraseña" />
+          </span>
         </div>
+
+        <label for="confirmPassword">Confirmar contraseña</label>
+        <div class="password-wrapper">
+          <input type="password" id="confirmPassword" placeholder="Confirmar contraseña" required />
+          <span class="toggle-password" id="toggleConfirmPassword">
+            <img src="../public/assets/img/ojo.png" alt="Mostrar contraseña" />
+          </span>
+        </div>
+
         <button id="changeBtn">Guardar</button>
         <p id="changeMessage" class="message"></p>
       </div>


### PR DESCRIPTION
## Summary
- add second password field on change password page and show/hide toggles
- validate new password strength and confirmation match

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6886525afa8c8320a1d47fb153e7fe36