### PR TITLE
Restrict cancel action to admins

### DIFF
--- a/backend/src/controllers/cambioEstadoController.js
+++ b/backend/src/controllers/cambioEstadoController.js
@@ -2,9 +2,14 @@ const cambioEstadoService = require('../services/cambioEstadoService');
 
 const cambiarEstado = async (req, res) => {
   const { radicado, estado } = req.body;
+  const userRole = req.user?.rol;
 
   if (!radicado || !estado) {
     return res.status(400).json({ mensaje: 'Radicado y estado son requeridos' });
+  }
+
+  if (Number(estado) === 5 && userRole !== 'admin') {
+    return res.status(403).json({ mensaje: 'Solo los administradores pueden cancelar tickets' });
   }
 
   try {

--- a/backend/src/routes/cambioEstadoRoutes.js
+++ b/backend/src/routes/cambioEstadoRoutes.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const cambioEstadoController = require('../controllers/cambioEstadoController');
+const { authenticateToken } = require('../middlewares/authMiddleware');
 
 // Ruta para cambiar el estado del ticket
-router.post('/cambiar-estado', cambioEstadoController.cambiarEstado);
+router.post('/cambiar-estado', authenticateToken, cambioEstadoController.cambiarEstado);
 
 module.exports = router;

--- a/frontend/js/detalle-ticket.js
+++ b/frontend/js/detalle-ticket.js
@@ -282,14 +282,20 @@ document.getElementById('btnAplicarRedireccion').addEventListener('click', async
 async function cargarEstados() {
     const selectEstado = document.getElementById('filtro-estado');
     if (!selectEstado) return;
-  
+
     try {
       const res = await fetch(`${API_URL}/estados`);
       if (!res.ok) throw new Error('Error al cargar estados');
       const data = await res.json();
-  
+
+      const userData = JSON.parse(localStorage.getItem("userData")) || {};
+      const esAdmin = userData.rol === 'admin';
+
       selectEstado.innerHTML = '<option value="">Seleccione un estado</option>';
       data.forEach(estado => {
+        if (!esAdmin && estado.nombre_estado.toLowerCase() === 'cancelado') {
+          return; // ocultar opción cancelar para roles no admin
+        }
         const option = document.createElement('option');
         option.value = estado.id;
         option.textContent = estado.nombre_estado;


### PR DESCRIPTION
## Summary
- protect `cambiar-estado` route with JWT authentication
- only allow admins to change a ticket to the *cancelado* state
- hide the "cancelado" option in ticket detail for non-admin roles

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688658298f148320bfdc612600d9ed2d