### PR TITLE
Fix admin state change authorization

### DIFF
--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -33,8 +33,9 @@ document.getElementById('loginBtn').addEventListener('click', async () => {
             showMessage(`Bienvenido ${data.user.nombre}!`, 'success');
 
             // Almacenar datos de sesión
+            const userWithToken = { ...data.user, token: data.token };
             localStorage.setItem('authToken', data.token);
-            localStorage.setItem('userData', JSON.stringify(data.user));
+            localStorage.setItem('userData', JSON.stringify(userWithToken));
 
             // Redirigir según si debe cambiar contraseña
             setTimeout(() => {

--- a/frontend/js/detalle-ticket.js
+++ b/frontend/js/detalle-ticket.js
@@ -63,9 +63,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       // (Opcional) puedes enviar estas respuestas al backend si tu endpoint lo admite
 
       try {
+        const userData = JSON.parse(localStorage.getItem("userData"));
         const cambio = await fetch('http://localhost:4000/api/cambiar-estado', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${userData.token}`
+          },
           body: JSON.stringify({ radicado, estado: 4 })
         });
         if (!cambio.ok) throw new Error('Error al cambiar el estado');
@@ -118,7 +122,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Cambiar estado a 4 (rechazado)
             const cambio = await fetch('http://localhost:4000/api/cambiar-estado', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${userData.token}`
+            },
             body: JSON.stringify({ radicado, estado: 1 })
             });
             if (!cambio.ok) throw new Error('Error al cambiar el estado');
@@ -184,9 +191,13 @@ async function configurarCambioDeEstado(radicado) {
       const confirmar = confirm('¿Confirmas que deseas cambiar el estado del ticket?');
       if (!confirmar) return;
 
+      const userData = JSON.parse(localStorage.getItem("userData"));
       await fetch('http://localhost:4000/api/cambiar-estado', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${userData.token}`
+        },
         body: JSON.stringify({ radicado, estado: nuevoEstado }),
       });
 


### PR DESCRIPTION
## Summary
- store JWT token in `userData` on login so it can be reused
- include Authorization header when updating ticket status

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887756c72ec832096b0a550e93bed3d