### PR TITLE
Restrict estado changes to admin roles

### DIFF
--- a/backend/src/controllers/cambioEstadoController.js
+++ b/backend/src/controllers/cambioEstadoController.js
@@ -3,9 +3,14 @@ const cambioEstadoService = require('../services/cambioEstadoService');
 const cambiarEstado = async (req, res) => {
   const { radicado, estado } = req.body;
   const userRole = req.user?.rol;
+  const permittedRoles = ['admin', 'usuario administrativo'];
 
   if (!radicado || !estado) {
     return res.status(400).json({ mensaje: 'Radicado y estado son requeridos' });
+  }
+
+  if (!permittedRoles.includes(userRole)) {
+    return res.status(403).json({ mensaje: 'No autorizado para cambiar estados' });
   }
 
   if (Number(estado) === 5 && userRole !== 'admin') {


### PR DESCRIPTION
## Summary
- require authenticated role to be `admin` or `usuario administrativo` before allowing a ticket state change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68878e51bcc88320991944f3527e3b2d