### PR TITLE
Add satisfaction survey endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -38,6 +38,7 @@ try {
   const detalleTicketRoutes = require('./src/routes/detalle-ticket');
   const solicitudesAtendidasTicketsRoutes = require('./src/routes/solicitudesAtendidasRoutes');
   const respuestaRoutes = require('./src/routes/respuestaRoutes');
+  const satisfaccionRoutes = require('./src/routes/satisfaccionRoutes');
   const redireccionarRoutes = require('./src/routes/redireccionarRoutes');
 
   app.use(bodyParser.json());  
@@ -53,7 +54,8 @@ try {
   app.use('/api/generales', solicitudesGeneralesTicketsRoutes);
   app.use('/api/atendidas', solicitudesAtendidasTicketsRoutes);
   app.use('/api/responder', respuestaRoutes);
-  
+  app.use('/api', satisfaccionRoutes);
+
   console.log('Todas las rutas cargadas correctamente');
 } catch (err) {
   console.error('Error al cargar rutas:', err);

--- a/backend/src/controllers/satisfaccionController.js
+++ b/backend/src/controllers/satisfaccionController.js
@@ -1,0 +1,17 @@
+const satisfaccionService = require('../services/satisfaccionService');
+
+exports.guardarEncuesta = async (req, res) => {
+  try {
+    const { ticket_id, q1, q3 } = req.body;
+
+    if (!ticket_id || !q1 || !q3) {
+      return res.status(400).json({ error: 'Datos incompletos' });
+    }
+
+    const id = await satisfaccionService.guardarEncuesta({ ticket_id, q1, q3 });
+    res.status(201).json({ success: true, id });
+  } catch (error) {
+    console.error('Error al guardar encuesta:', error);
+    res.status(500).json({ error: 'Error al guardar la encuesta' });
+  }
+};

--- a/backend/src/routes/satisfaccionRoutes.js
+++ b/backend/src/routes/satisfaccionRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const satisfaccionController = require('../controllers/satisfaccionController');
+const { authenticateToken } = require('../middlewares/authMiddleware');
+
+router.post('/encuesta-satisfaccion', authenticateToken, satisfaccionController.guardarEncuesta);
+
+module.exports = router;

--- a/backend/src/services/satisfaccionService.js
+++ b/backend/src/services/satisfaccionService.js
@@ -1,0 +1,13 @@
+const db = require('../../dbConfig');
+
+const guardarEncuesta = async ({ ticket_id, q1, q3 }) => {
+  const [result] = await db.query(
+    `INSERT INTO encuestas_satisfaccion (ticket_id, q1, q3) VALUES (?, ?, ?)`,
+    [ticket_id, q1, q3]
+  );
+  return result.insertId;
+};
+
+module.exports = {
+  guardarEncuesta
+};

--- a/create_database.sql
+++ b/create_database.sql
@@ -162,6 +162,16 @@ CREATE TABLE respuestas_ticket (
   FOREIGN KEY (id_usuario) REFERENCES usuarios(id)
 ) ENGINE=InnoDB;
 
+-- Tabla de encuestas de satisfacción
+CREATE TABLE encuestas_satisfaccion (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  ticket_id INT NOT NULL,
+  q1 ENUM('si','no') NOT NULL,
+  q3 INT NOT NULL,
+  fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
 -- Insertar datos iniciales
 INSERT INTO tipo_documento (nombre, abreviatura, descripcion) VALUES
 ('Cédula de Ciudadanía', 'CC', 'Documento de identificación para ciudadanos colombianos mayores de edad.'),

--- a/frontend/js/detalle-ticket.js
+++ b/frontend/js/detalle-ticket.js
@@ -57,13 +57,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     const formEncuesta = document.getElementById('formEncuestaSatisfaccion');
     formEncuesta.addEventListener('submit', async (e) => {
       e.preventDefault();
-      // Todos los campos tienen `required`, así que si llega aquí, están llenos
       const formData = new FormData(formEncuesta);
       const respuestas = Object.fromEntries(formData.entries());
-      // (Opcional) puedes enviar estas respuestas al backend si tu endpoint lo admite
 
       try {
         const userData = JSON.parse(localStorage.getItem("userData"));
+
+        await fetch('http://localhost:4000/api/encuesta-satisfaccion', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${userData.token}`
+          },
+          body: JSON.stringify(respuestas)
+        });
+
         const cambio = await fetch('http://localhost:4000/api/cambiar-estado', {
           method: 'POST',
           headers: {
@@ -72,10 +80,10 @@ document.addEventListener('DOMContentLoaded', async () => {
           },
           body: JSON.stringify({ radicado, estado: 4 })
         });
+
         if (!cambio.ok) throw new Error('Error al cambiar el estado');
-        // Cierra el modal al finalizar
+
         modalSatisfaccion.style.display = 'none';
-        // (Opcional) recarga detalles o redirige
         location.reload();
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- add survey table in schema
- add service, controller, route to handle survey submissions
- wire survey route in server
- send survey data from the ticket detail page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887b45104408320b9eb1a27d99ab240