### PR TITLE
Improve satisfaction save time

### DIFF
--- a/backend/src/controllers/cambioEstadoController.js
+++ b/backend/src/controllers/cambioEstadoController.js
@@ -1,5 +1,4 @@
 const cambioEstadoService = require('../services/cambioEstadoService');
-console.log('[DEBUG] req.user:', require.user);
 
 const cambiarEstado = async (req, res) => {
   const { radicado, estado } = req.body;

--- a/backend/src/services/cambioEstadoService.js
+++ b/backend/src/services/cambioEstadoService.js
@@ -166,14 +166,18 @@ const cambiarEstado = async (radicado, nuevoEstado) => {
                 const { email, primer_nombre } = userRows[0];
                 const { nombre_estado } = estadoRows[0];
 
-                await enviarCorreo({
+                enviarCorreo({
                     to: email,
                     subject: `Actualización de su ticket #${radicado}`,
                     text: `Hola ${primer_nombre},\n\nEl estado de su ticket ${radicado} ha cambiado a \"${nombre_estado}\".`,
                     html: `<p>Hola ${primer_nombre},</p><p>El estado de su ticket <strong>${radicado}</strong> ha cambiado a <strong>${nombre_estado}</strong>.</p>`
+                })
+                .then(() => {
+                    console.log('📧 Notificación enviada a', email);
+                })
+                .catch(notifyErr => {
+                    console.error('Error al enviar correo de notificación:', notifyErr);
                 });
-
-                console.log('📧 Notificación enviada a', email);
             }
         } catch (notifyErr) {
             console.error('Error al enviar correo de notificación:', notifyErr);

--- a/frontend/js/detalle-ticket.js
+++ b/frontend/js/detalle-ticket.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       try {
         const userData = JSON.parse(localStorage.getItem("userData"));
 
-        await fetch('http://localhost:4000/api/encuesta-satisfaccion', {
+        const encuestaPromise = fetch('http://localhost:4000/api/encuesta-satisfaccion', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           body: JSON.stringify(respuestas)
         });
 
-        const cambio = await fetch('http://localhost:4000/api/cambiar-estado', {
+        const cambioPromise = fetch('http://localhost:4000/api/cambiar-estado', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -81,7 +81,9 @@ document.addEventListener('DOMContentLoaded', async () => {
           body: JSON.stringify({ radicado, estado: 4 })
         });
 
-        if (!cambio.ok) throw new Error('Error al cambiar el estado');
+        const [encuesta, cambio] = await Promise.all([encuestaPromise, cambioPromise]);
+
+        if (!encuesta.ok || !cambio.ok) throw new Error('Error al enviar datos');
 
         modalSatisfaccion.style.display = 'none';
         location.reload();


### PR DESCRIPTION
## Summary
- avoid logging undefined `req` in cambioEstado controller
- send notification email asynchronously
- parallelize satisfaction survey and status update

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887c1c360548320962f8ee935ab449b