### PR TITLE
Switch front-end fetches to production API

### DIFF
--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -11,7 +11,7 @@ document.getElementById('loginBtn').addEventListener('click', async () => {
     showMessage('Verificando credenciales...', 'info');
 
     try {
-        const response = await fetch('http://localhost:4000/api/auth/login', {
+        const response = await fetch(`${BASE_URL}/api/auth/login`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/js/cambiar-contrasena.js
+++ b/frontend/js/cambiar-contrasena.js
@@ -29,7 +29,7 @@ btn.addEventListener('click', async () => {
 
     const token = localStorage.getItem('authToken');
     try {
-        const response = await fetch('http://localhost:4000/api/auth/change-password', {
+        const response = await fetch(`${BASE_URL}/api/auth/change-password`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/js/categorias-dinamicas.js
+++ b/frontend/js/categorias-dinamicas.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         // 3. Obtener campos del formulario
-        const response = await fetch(`http://localhost:4000/api/areas/${idCategoria}/campos`);
+        const response = await fetch(`${BASE_URL}/api/areas/${idCategoria}/campos`);
         
         if (!response.ok) {
             const errorData = await response.json();
@@ -387,7 +387,7 @@ form.addEventListener('submit', async (e) => {
         formData.append('fileInfos', JSON.stringify(fileInfosArray));
 
         // Enviar
-        const response = await fetch('http://localhost:4000/api/tickets', {
+        const response = await fetch(`${BASE_URL}/api/tickets`, {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${userData.token}`

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -1,0 +1,2 @@
+// URL base para todas las peticiones al backend
+const BASE_URL = 'https://fomagmesayuda-api.herokuapp.com';

--- a/frontend/js/crear-solicitud.js
+++ b/frontend/js/crear-solicitud.js
@@ -11,7 +11,7 @@ async function initCrearSolicitud() {
         contenedor.innerHTML = '<div class="cargando">Cargando áreas disponibles...</div>';
 
         console.log('Solicitando áreas al API...');
-        const response = await fetch('http://localhost:4000/api/areas', {
+        const response = await fetch(`${BASE_URL}/api/areas`, {
             headers: {
                 'Authorization': `Bearer ${localStorage.getItem('token')}`
             }
@@ -109,7 +109,7 @@ async function cargarCategorias(idArea, contenedor) {
     contenedor.innerHTML = '<div class="cargando">Cargando categorías...</div>';
 
     try {
-        const response = await fetch(`http://localhost:4000/api/areas/${idArea}/categorias`);
+        const response = await fetch(`${BASE_URL}/api/areas/${idArea}/categorias`);
 
         if (!response.ok) throw new Error('Error al obtener categorías');
 
@@ -207,7 +207,7 @@ async function cargarFormulario(idCategoria) {
         }
 
         // 3. Obtener campos del formulario
-        const response = await fetch(`http://localhost:4000/api/areas/${idCategoria}/campos`);
+        const response = await fetch(`${BASE_URL}/api/areas/${idCategoria}/campos`);
         
         if (!response.ok) {
             const errorData = await response.json();
@@ -390,7 +390,7 @@ async function cargarFormulario(idCategoria) {
                 }));
 
                 // Enviar al backend
-                const response = await fetch('http://localhost:4000/api/tickets', {
+                const response = await fetch(`${BASE_URL}/api/tickets`, {
                     method: 'POST',
                     headers: {
                         'Authorization': `Bearer ${userData.token}`

--- a/frontend/js/detalle-ticket.js
+++ b/frontend/js/detalle-ticket.js
@@ -1,6 +1,5 @@
 if (typeof API_URL === 'undefined') {
-    var API_URL = 'http://localhost:4000/api/filtros'; // Usamos 'var' para que sea accesible globalmente
-}
+    var API_URL = `${BASE_URL}/api/filtros`;
 
 document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);
@@ -12,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   try {
-    const response = await fetch(`http://localhost:4000/api/detalle-ticket/${encodeURIComponent(radicado)}`);
+    const response = await fetch(`${BASE_URL}/api/detalle-ticket/${encodeURIComponent(radicado)}`);
     if (!response.ok) throw new Error('Error al obtener los datos');
 
     const data = await response.json();
@@ -63,7 +62,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       try {
         const userData = JSON.parse(localStorage.getItem("userData"));
 
-        const encuestaPromise = fetch('http://localhost:4000/api/encuesta-satisfaccion', {
+        const encuestaPromise = fetch(`${BASE_URL}/api/encuesta-satisfaccion`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -72,7 +71,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           body: JSON.stringify(respuestas)
         });
 
-        const cambioPromise = fetch('http://localhost:4000/api/cambiar-estado', {
+        const cambioPromise = fetch(`${BASE_URL}/api/cambiar-estado`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -130,7 +129,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!userData) throw new Error('Usuario no autenticado');
             
             // Cambiar estado a 4 (rechazado)
-            const cambio = await fetch('http://localhost:4000/api/cambiar-estado', {
+              const cambio = await fetch(`${BASE_URL}/api/cambiar-estado`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -147,7 +146,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             formData.append('mensaje', justificacion);
             formData.append('interno', false);
 
-            const respuestaResponse = await fetch('http://localhost:4000/api/responder', {
+              const respuestaResponse = await fetch(`${BASE_URL}/api/responder`, {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${userData.token}`
@@ -202,7 +201,7 @@ async function configurarCambioDeEstado(radicado) {
       if (!confirmar) return;
 
       const userData = JSON.parse(localStorage.getItem("userData"));
-      await fetch('http://localhost:4000/api/cambiar-estado', {
+        await fetch(`${BASE_URL}/api/cambiar-estado`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -249,7 +248,7 @@ document.getElementById('btnAplicarRedireccion').addEventListener('click', async
 
   try {
     // 1. Redireccionamiento
-    const redireccionResponse = await fetch('http://localhost:4000/api/redireccionar', {
+      const redireccionResponse = await fetch(`${BASE_URL}/api/redireccionar`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -275,7 +274,7 @@ document.getElementById('btnAplicarRedireccion').addEventListener('click', async
     formData.append('mensaje', justificacion);
     formData.append('interno', true);
 
-    const respuestaResponse = await fetch('http://localhost:4000/api/responder', {
+      const respuestaResponse = await fetch(`${BASE_URL}/api/responder`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${userData.token}`
@@ -426,7 +425,7 @@ function renderRespuestas(respuestas) {
             ${esInterno ? '<span class="etiqueta-interno">🔒 Comentario interno</span>' : ''}
             <p>${respuesta.mensaje}</p>
             ${respuesta.ruta_archivo 
-                ? `<a href="http://localhost:4000/uploads/${respuesta.ruta_archivo}" target="_blank">📁 Ver archivo</a>` 
+                ? `<a href="${BASE_URL}/uploads/${respuesta.ruta_archivo}" target="_blank">📁 Ver archivo</a>` 
                 : ''}
             <small>
               <strong>${respuesta.nombre_usuario || 'Sistema'} ${respuesta.apellido_usuario || ''}</strong> | 
@@ -516,7 +515,7 @@ function renderTicket(data) {
                 rutaNormalizada = rutaNormalizada.substring(indexUploads + 'uploads/'.length);
             }
 
-            const downloadUrl = `http://localhost:4000/uploads/${encodeURIComponent(rutaNormalizada)}`;
+            const downloadUrl = `${BASE_URL}/uploads/${encodeURIComponent(rutaNormalizada)}`;
 
             archivosHtml += `
                 <li style="margin-bottom: 15px;">
@@ -608,7 +607,7 @@ function renderTicket(data) {
         respuestaForm.prepend(loadingMessage);
 
         try {
-            const response = await fetch('http://localhost:4000/api/responder', {
+            const response = await fetch(`${BASE_URL}/api/responder`, {
                 method: 'POST',
                 headers: {
                     'Authorization': `Bearer ${userData.token}`
@@ -680,7 +679,7 @@ comentarioInternoBtn.addEventListener('click', async () => {
     respuestaForm.prepend(loadingMessage);
 
     try {
-        const response = await fetch('http://localhost:4000/api/responder', {
+        const response = await fetch(`${BASE_URL}/api/responder`, {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${userData.token}`
@@ -850,7 +849,7 @@ document.getElementById('btnCerrarModal').addEventListener('click', () => {
 
 function previsualizarArchivo(ruta, nombre) {
     const extension = nombre.split('.').pop().toLowerCase();
-    const fileUrl = `http://localhost:4000/uploads/${encodeURIComponent(ruta)}`;
+    const fileUrl = `${BASE_URL}/uploads/${encodeURIComponent(ruta)}`;
 
     if (['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'].includes(extension)) {
         window.open(fileUrl, '_blank');

--- a/frontend/js/mis-asignadas.js
+++ b/frontend/js/mis-asignadas.js
@@ -1,10 +1,10 @@
 // Comprobar si ya están definidas las constantes
 if (typeof API_URL === 'undefined') {
-    var API_URL = 'http://localhost:4000/api/filtros'; // Usamos 'var' para que sea accesible globalmente
+    var API_URL = `${BASE_URL}/api/filtros`;
 }
 
 
-var TICKETS_URL = 'http://localhost:4000/api/asignadas/MisAsignadasTickets';
+var TICKETS_URL = `${BASE_URL}/api/asignadas/MisAsignadasTickets`;
 
 
 function initMisAsignadas() {

--- a/frontend/js/mis-solicitudes.js
+++ b/frontend/js/mis-solicitudes.js
@@ -1,9 +1,9 @@
 // Comprobar si ya están definidas las constantes
 if (typeof API_URL === 'undefined') {
-    var API_URL = 'http://localhost:4000/api/filtros'; // Usamos 'var' para que sea accesible globalmente
+    var API_URL = `${BASE_URL}/api/filtros`;
 }
 
-var TICKETS_URL = 'http://localhost:4000/api/misSolicitudesTickets';
+var TICKETS_URL = `${BASE_URL}/api/misSolicitudesTickets`;
 
 
 

--- a/frontend/js/solicitudes-generales.js
+++ b/frontend/js/solicitudes-generales.js
@@ -1,7 +1,7 @@
-var TICKETS_URL = 'http://localhost:4000/api/generales/solicitudesGeneralesTickets';
+var TICKETS_URL = `${BASE_URL}/api/generales/solicitudesGeneralesTickets`;
 
 if (typeof API_URL === 'undefined') {
-    var API_URL = 'http://localhost:4000/api/filtros'; // Usamos 'var' para que sea accesible globalmente
+    var API_URL = `${BASE_URL}/api/filtros`; // Usamos var para que sea accesible globalmente
 }
 
 function initMisSolicitudes() {

--- a/frontend/js/solucionadas.js
+++ b/frontend/js/solucionadas.js
@@ -1,7 +1,7 @@
-var TICKETS_URL = 'http://localhost:4000/api/atendidas/solicitudesAtendidas';
+var TICKETS_URL = `${BASE_URL}/api/atendidas/solicitudesAtendidas`;
 
 if (typeof API_URL === 'undefined') {
-    var API_URL = 'http://localhost:4000/api/filtros'; // Usamos 'var' para que sea accesible globalmente
+    var API_URL = `${BASE_URL}/api/filtros`; // Usamos var para que sea accesible globalmente
 }
 
 function initMisSolicitudes() {

--- a/frontend/views/cambiar-contrasena.html
+++ b/frontend/views/cambiar-contrasena.html
@@ -42,6 +42,7 @@
     <p>© 2025 FOMAG. Todos los derechos reservados.</p>
   </footer>
 
+  <script src="../js/config.js"></script>
   <script src="../js/cambiar-contrasena.js"></script>
 </body>
 </html>

--- a/frontend/views/categorias-dinamicas.html
+++ b/frontend/views/categorias-dinamicas.html
@@ -25,6 +25,7 @@
             </div>
         </div>
     </div>
+  <script src="../js/config.js"></script>
 
     <script src="../js/categorias-dinamicas.js"></script>
 </body>

--- a/frontend/views/detalle-ticket.html
+++ b/frontend/views/detalle-ticket.html
@@ -188,6 +188,7 @@
         </div>
 
     </main>     
+  <script src="../js/config.js"></script>
 
     <script src="../js/detalle-ticket.js"></script>
 </body>

--- a/frontend/views/login.html
+++ b/frontend/views/login.html
@@ -40,6 +40,7 @@
     <p>© 2025 FOMAG. Todos los derechos reservados.</p>
   </footer>
 
+  <script src="../js/config.js"></script>
   <script src="../js/auth.js"></script>
 </body>
 </html>

--- a/frontend/views/panel-principal.html
+++ b/frontend/views/panel-principal.html
@@ -74,6 +74,7 @@
             </div>
         </main>
     </div>
+  <script src="../js/config.js"></script>
     <script src="../js/panel-principal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- define `BASE_URL` constant for API
- include `config.js` across login and other pages
- update all front-end fetch requests to use the new base URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688825bc84d08320b599359777d9df38