### PR TITLE
Restrict attachment types and total size

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ El backend del módulo ha sido desarrollado con **Node.js**, utilizando una estr
 - `routes/`: Define los endpoints disponibles de la API.
 - `server.js`: Archivo principal para levantar el servidor Express.
 - `multer`: Librería utilizada para la carga de archivos adjuntos en los tickets.
+  Los archivos permitidos son únicamente `.txt`, `.jpg` y `.xlsx` y el tamaño
+  total por solicitud no puede exceder los **5 MB**.
 
 ### Frontend
 

--- a/src/config/multerConfig.js
+++ b/src/config/multerConfig.js
@@ -30,9 +30,13 @@ const storage = multer.diskStorage({
 });
 
 // Filtros de archivo (seguridad básica)
-  // Se permiten imágenes, PDF, documentos y archivos comprimidos
+// Solo se permiten .txt, .jpg y .xlsx
 const fileFilter = (req, file, cb) => {
-  const allowedTypes = ['image/jpeg', 'image/png', 'application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/zip', 'application/x-zip-compressed', 'text/plain'];
+  const allowedTypes = [
+    'text/plain',
+    'image/jpeg',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  ];
   if (allowedTypes.includes(file.mimetype)) {
     cb(null, true);
   } else {

--- a/src/middlewares/totalSizeLimit.js
+++ b/src/middlewares/totalSizeLimit.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+
+const MAX_TOTAL_SIZE = 5 * 1024 * 1024; // 5MB
+
+module.exports = (req, res, next) => {
+  const files = req.files || [];
+  const totalSize = files.reduce((sum, f) => sum + (f.size || 0), 0);
+
+  if (totalSize > MAX_TOTAL_SIZE) {
+    files.forEach(f => {
+      if (f.path && fs.existsSync(f.path)) {
+        fs.unlink(f.path, () => {});
+      }
+    });
+    return res.status(400).json({
+      error: 'El tamaño total de los archivos supera el límite de 5MB'
+    });
+  }
+
+  next();
+};

--- a/src/routes/respuestaRoutes.js
+++ b/src/routes/respuestaRoutes.js
@@ -2,8 +2,9 @@
 const express = require('express');
 const router = express.Router();
 const upload = require('../config/multerConfig');
+const totalSizeLimit = require('../middlewares/totalSizeLimit');
 const respuestaController = require('../controllers/respuestaController');
 
-router.post('/', upload.any(), respuestaController.crearRespuesta);
+router.post('/', upload.any(), totalSizeLimit, respuestaController.crearRespuesta);
 
 module.exports = router;

--- a/src/routes/ticketsRoutes.js
+++ b/src/routes/ticketsRoutes.js
@@ -2,7 +2,8 @@ const express = require('express');
 const router = express.Router();
 const ticketsController = require('../controllers/ticketsController');
 const upload = require('../config/multerConfig');
+const totalSizeLimit = require('../middlewares/totalSizeLimit');
 
-router.post('/', upload.any(), ticketsController.createTicket);
+router.post('/', upload.any(), totalSizeLimit, ticketsController.createTicket);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- restrict uploads to `.txt`, `.jpg` and `.xlsx` with 5MB limit each
- add middleware to enforce 5MB total upload size
- use new middleware in tickets and responses routes
- document upload restrictions in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688963308c588320b96c7ae95f375780