### PR TITLE
Use category name as ticket subject

### DIFF
--- a/frontend/js/categorias-dinamicas.js
+++ b/frontend/js/categorias-dinamicas.js
@@ -17,12 +17,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         // 2. Actualizar título con el nombre de la categoría en mayúsculas
         if (categoria?.nombre) {
             formTitle.textContent = categoria.nombre.toUpperCase();
-
-            // Colocar el nombre de la categoría en el campo Asunto
-            const asuntoInput = document.getElementById('asunto');
-            if (asuntoInput) {
-                asuntoInput.value = categoria.nombre;
-            }
         } else {
             formTitle.textContent = 'FORMULARIO DE TICKET'; // Fallback
         }
@@ -376,8 +370,10 @@ form.addEventListener('submit', async (e) => {
             }
         });
 
-        // Agregar info general
-        const asunto = document.getElementById('asunto').value.trim();
+        // Agregar info general usando el nombre de la categoría como asunto
+        const categoriaDataStr = localStorage.getItem('categoriaSeleccionada');
+        const categoriaData = categoriaDataStr ? JSON.parse(categoriaDataStr) : {};
+        const asunto = categoriaData.nombre || 'Sin asunto';
         const descripcion = document.getElementById('descripcion').value.trim();
 
         formData.append('ticket', JSON.stringify({

--- a/frontend/js/crear-solicitud.js
+++ b/frontend/js/crear-solicitud.js
@@ -203,11 +203,6 @@ async function cargarFormulario(idCategoria) {
         if (categoria?.nombre) {
             formTitle.textContent = categoria.nombre.toUpperCase();
 
-            // Colocar el nombre de la categoría en el campo Asunto
-            const asuntoInput = document.getElementById('asunto');
-            if (asuntoInput) {
-                asuntoInput.value = categoria.nombre;
-            }
         } else {
             formTitle.textContent = 'FORMULARIO DE TICKET'; // Fallback
         }
@@ -386,12 +381,16 @@ async function cargarFormulario(idCategoria) {
                     }
                 }
 
+                // Determinar asunto usando el nombre de la categoría
+                const categoriaDataStr = localStorage.getItem('categoriaSeleccionada');
+                const categoriaData = categoriaDataStr ? JSON.parse(categoriaDataStr) : {};
+
                 // Agregar datos del ticket
                 formData.append('ticket', JSON.stringify({
                     id_categoria: parseInt(idCategoria),
                     id_usuario: userData.id,
                     id_estado: 2,
-                    asunto: document.getElementById('asunto').value,
+                    asunto: categoriaData.nombre || 'Sin asunto',
                     descripcion: document.getElementById('descripcion').value,
                     campos: camposValues
                 }));
@@ -416,7 +415,6 @@ async function cargarFormulario(idCategoria) {
                 // Limpiar formulario (sin cerrar el modal)
                 form.reset();
                 if (fileInput) fileInput.value = ''; // Limpiar input de archivo
-                document.getElementById('asunto').value = '';
                 document.getElementById('descripcion').value = '';
 
             } catch (error) {

--- a/frontend/views/categorias-dinamicas.html
+++ b/frontend/views/categorias-dinamicas.html
@@ -10,10 +10,8 @@
     <div class="form-container">
         <h1 class="form-title">Formulario de Ticket</h1>
 
-        <!-- Campo Asunto agregado con la clase form-field para seguir el diseño -->
+        <!-- Campo de descripción del caso -->
         <div class="form-field">
-            <label for="asunto">Asunto <span class="required">*</span></label>
-            <input type="text" id="asunto" name="asunto" placeholder="Escribe el asunto del ticket" required>
             <label>Descripción del Caso</label>
             <textarea id="descripcion" name="descripcion" placeholder="Escribe la descripcion del ticket" rows="4"></textarea>
         </div>

--- a/frontend/views/crear-solicitud.html
+++ b/frontend/views/crear-solicitud.html
@@ -15,8 +15,6 @@
                 <h1 class="form-title">Formulario de Ticket</h1>
 
                 <div class="form-field">
-                    <label for="asunto">Asunto <span class="required">*</span></label>
-                    <input type="text" id="asunto" name="asunto" placeholder="Escribe el asunto del ticket" required>
                     <label>Descripción del Caso</label>
                     <textarea id="descripcion" name="descripcion" placeholder="Escribe la descripcion del ticket" rows="4"></textarea>
                 </div>

--- a/src/services/ticketsService.js
+++ b/src/services/ticketsService.js
@@ -7,14 +7,20 @@ exports.processTicketCreation = async ({ ticketData, files, fileInfos }) => {
   let conn;
   try {
     // Validación básica
-    if (!ticketData || !ticketData.id_categoria || !ticketData.id_usuario || !ticketData.asunto) {
+    if (!ticketData || !ticketData.id_categoria || !ticketData.id_usuario) {
       throw new Error('Datos del ticket incompletos');
     }
 
     conn = await pool.getConnection();
     await conn.beginTransaction();
 
-    const asunto = (ticketData.asunto || 'Sin asunto').toString().trim();
+    const [catRows] = await conn.query(
+      'SELECT nombre FROM categorias WHERE id = ?',
+      [ticketData.id_categoria]
+    );
+    const categoriaNombre = catRows[0]?.nombre || '';
+
+    const asunto = (ticketData.asunto || categoriaNombre || 'Sin asunto').toString().trim();
     const descripcion = (ticketData.descripcion || 'Sin descripcion').toString().trim();
 
     // 1) Crear el ticket


### PR DESCRIPTION
## Summary
- remove subject textbox from ticket creation forms
- use selected category name as the ticket subject when creating a ticket
- fetch category name on the backend if subject is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a2f67698c83208020245d7a225081