### PR TITLE
Fix static path for ticket details

### DIFF
--- a/frontend/js/mis-asignadas.js
+++ b/frontend/js/mis-asignadas.js
@@ -311,8 +311,8 @@ async function cargarTickets(userId, filters = {}) {
 
             // Asignar un evento click a la fila para abrir la nueva pestaña
             row.addEventListener('click', () => {
-                // Reemplaza '/detalles_ticket/${ticket.radicado}' con la URL correspondiente
-                window.open(`/frontend/views/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
+                // Abrir el detalle del ticket en una nueva pestaña
+                window.open(`/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
 
             });
 

--- a/frontend/js/mis-solicitudes.js
+++ b/frontend/js/mis-solicitudes.js
@@ -312,8 +312,8 @@ async function cargarTickets(userId, filters = {}) {
 
             // Asignar un evento click a la fila para abrir la nueva pestaña
             row.addEventListener('click', () => {
-                // Reemplaza '/detalles_ticket/${ticket.radicado}' con la URL correspondiente
-                window.open(`/frontend/views/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
+                // Abrir el detalle del ticket en una nueva pestaña
+                window.open(`/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
 
             });
 

--- a/frontend/js/solicitudes-generales.js
+++ b/frontend/js/solicitudes-generales.js
@@ -336,7 +336,7 @@ async function cargarTickets(userId, filters = {}) {
 
             // Asignar un evento click a la fila para abrir la nueva pestaña
             row.addEventListener('click', () => {
-                window.open(`/frontend/views/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
+                window.open(`/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
             });
 
             tbody.appendChild(row);

--- a/frontend/js/solucionadas.js
+++ b/frontend/js/solucionadas.js
@@ -324,7 +324,7 @@ async function cargarTickets(userId, filters = {}) {
 
             // Asignar un evento click a la fila para abrir la nueva pestaña
             row.addEventListener('click', () => {
-                window.open(`/frontend/views/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
+                window.open(`/detalle-ticket.html?radicado=${ticket.radicado}`, '_blank');
             });
 
             tbody.appendChild(row);

--- a/frontend/views/cambiar-contrasena.html
+++ b/frontend/views/cambiar-contrasena.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <img src="/frontend/public/assets/img/Logo.png" alt="Logo FOMAG" class="logo" />
+    <img src="../public/assets/img/Logo.png" alt="Logo FOMAG" class="logo" />
     <h1>Mesa de ayuda FOMAG</h1>
   </header>
 


### PR DESCRIPTION
## Summary
- correct the link to detailed ticket view in the frontend JS files
- update logo path on password change page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a3820a9dc8320b0ee7eee70d7b374