### PR TITLE
Fix file download URL encoding

### DIFF
--- a/frontend/js/detalle-ticket.js
+++ b/frontend/js/detalle-ticket.js
@@ -515,7 +515,7 @@ function renderTicket(data) {
                 rutaNormalizada = rutaNormalizada.substring(indexUploads + 'uploads/'.length);
             }
 
-            const downloadUrl = `${BASE_URL}/uploads/${encodeURIComponent(rutaNormalizada)}`;
+            const downloadUrl = `${BASE_URL}/uploads/${encodeURI(rutaNormalizada)}`;
 
             archivosHtml += `
                 <li style="margin-bottom: 15px;">


### PR DESCRIPTION
## Summary
- fix download path encoding for evidence links

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a3b01435c8320b8581add9fc81d48