### PR TITLE
Restrict ticket attachment types

### DIFF
--- a/frontend/views/detalle-ticket.html
+++ b/frontend/views/detalle-ticket.html
@@ -83,7 +83,7 @@
                 </div>
                 <div class="form-group">
                     <label for="archivo">Adjuntar archivo</label>
-                    <input type="file" id="archivo" name="archivo" />
+                    <input type="file" id="archivo" name="archivo" accept=".txt, .xlsx, .jpg" />
                 </div>
                 <div class="form-group botones-chat">
                     <label>&nbsp;</label>


### PR DESCRIPTION
## Summary
- restrict allowed attachment formats in Detalle Ticket page

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a49f7c4288320af27001d078a8a86