### PR TITLE
Add dropdown logout in header

### DIFF
--- a/frontend/css/panel-principal.css
+++ b/frontend/css/panel-principal.css
@@ -40,6 +40,11 @@ header {
     margin: 0;
 }
 
+.usuario-menu {
+    position: relative;
+    margin-right: 30px;
+}
+
 .usuario-nombre {
     font-weight: bold;
     text-transform: uppercase;
@@ -48,11 +53,41 @@ header {
     padding: 8px 15px;
     border-radius: 20px;
     color: white;
-    margin-right: 30px;
     white-space: nowrap;
     max-width: 250px;
     overflow: hidden;
     text-overflow: ellipsis;
+    cursor: pointer;
+}
+
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 5px);
+    background: white;
+    color: #333;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    border-radius: 4px;
+    min-width: 150px;
+    z-index: 10001;
+}
+
+.dropdown-menu.show {
+    display: block;
+}
+
+.dropdown-menu button {
+    background: none;
+    border: none;
+    padding: 10px;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+}
+
+.dropdown-menu button:hover {
+    background: #f0f0f0;
 }
 
 .logo {
@@ -215,9 +250,11 @@ body.admin .admin-module.active {
         flex-direction: column;
     }
 
+    .usuario-menu {
+        margin-right: 10px;
+    }
     .usuario-nombre {
         font-size: 12px;
-        margin-right: 10px;
     }
 }
 

--- a/frontend/js/panel-principal.js
+++ b/frontend/js/panel-principal.js
@@ -12,6 +12,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Configurar interfaz de usuario
     setupUserInterface(userData);
 
+    // Preparar menú de usuario
+    setupUserDropdown();
+
     // Configurar navegación
     await setupModuleNavigation();
 });
@@ -176,5 +179,32 @@ function loadPanelAssets(panelId) {
         };
         document.body.appendChild(script);
     });
+}
+
+function setupUserDropdown() {
+    const nameElement = document.getElementById('usuarioNombre');
+    const dropdown = document.getElementById('userDropdown');
+    const logoutBtn = document.getElementById('logoutBtn');
+
+    if (!nameElement || !dropdown || !logoutBtn) return;
+
+    nameElement.addEventListener('click', (e) => {
+        dropdown.classList.toggle('show');
+        e.stopPropagation();
+    });
+
+    logoutBtn.addEventListener('click', logout);
+
+    document.addEventListener('click', (e) => {
+        if (!dropdown.contains(e.target) && e.target !== nameElement) {
+            dropdown.classList.remove('show');
+        }
+    });
+}
+
+function logout() {
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('userData');
+    window.location.href = 'login.html';
 }
 

--- a/frontend/views/panel-principal.html
+++ b/frontend/views/panel-principal.html
@@ -13,8 +13,13 @@
             <img src="../public/assets/img/Logo.png" alt="Logo" class="logo">
             <h1 class="titulo-app">Mesa de ayuda FOMAG</h1>
         </div>
-        <div class="usuario-nombre" id="usuarioNombre"></div>
-    </header>                
+        <div class="usuario-menu">
+            <div class="usuario-nombre" id="usuarioNombre"></div>
+            <div class="dropdown-menu" id="userDropdown">
+                <button id="logoutBtn">Cerrar sesión</button>
+            </div>
+        </div>
+    </header>
     
     <div class="dashboard-container">
         <nav class="sidebar" id="sidebar">


### PR DESCRIPTION
## Summary
- implement dropdown user menu with logout option
- style dropdown in header
- enable closing session and redirecting to login page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a70e297f4832081bf0cac48082743