### PR TITLE
Implementar registro inicial de usuario

### DIFF
--- a/frontend/js/cambiar-contrasena.js
+++ b/frontend/js/cambiar-contrasena.js
@@ -1,5 +1,11 @@
 const btn = document.getElementById('changeBtn');
 const messageDiv = document.getElementById('changeMessage');
+const primerNombreInput = document.getElementById('primerNombre');
+const segundoNombreInput = document.getElementById('segundoNombre');
+const primerApellidoInput = document.getElementById('primerApellido');
+const segundoApellidoInput = document.getElementById('segundoApellido');
+const emailInput = document.getElementById('email');
+const celularInput = document.getElementById('celular');
 const newPasswordInput = document.getElementById('newPassword');
 const confirmPasswordInput = document.getElementById('confirmPassword');
 const toggleNewPassword = document.getElementById('toggleNewPassword');
@@ -8,11 +14,17 @@ const eyeOpen = '../public/assets/img/ojo-abierto.png';
 const eyeClosed = '../public/assets/img/ojo.png';
 
 btn.addEventListener('click', async () => {
+    const primer_nombre = primerNombreInput.value.trim();
+    const segundo_nombre = segundoNombreInput.value.trim();
+    const primer_apellido = primerApellidoInput.value.trim();
+    const segundo_apellido = segundoApellidoInput.value.trim();
+    const email = emailInput.value.trim();
+    const celular = celularInput.value.trim();
     const newPassword = newPasswordInput.value.trim();
     const confirmPassword = confirmPasswordInput.value.trim();
 
-    if (!newPassword || !confirmPassword) {
-        showMessage('Debe completar ambos campos', 'error');
+    if (!primer_nombre || !primer_apellido || !email || !celular || !newPassword || !confirmPassword) {
+        showMessage('Por favor complete los campos obligatorios', 'error');
         return;
     }
 
@@ -35,11 +47,19 @@ btn.addEventListener('click', async () => {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${token}`
             },
-            body: JSON.stringify({ newPassword })
+            body: JSON.stringify({
+                newPassword,
+                primer_nombre,
+                segundo_nombre,
+                primer_apellido,
+                segundo_apellido,
+                email,
+                celular
+            })
         });
         const data = await response.json();
         if (!response.ok) throw new Error(data.message || 'Error');
-        showMessage('Contraseña actualizada', 'success');
+        showMessage('Datos actualizados', 'success');
         setTimeout(() => {
             window.location.href = 'panel-principal.html';
         }, 1500);

--- a/frontend/views/cambiar-contrasena.html
+++ b/frontend/views/cambiar-contrasena.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Cambiar Contraseña</title>
+  <title>Completar Registro</title>
   <link rel="stylesheet" href="../css/auth.css" />
 </head>
 <body>
@@ -14,8 +14,26 @@
 
   <main>
     <section class="login-container" aria-labelledby="change-title">
-      <h2 id="change-title">Actualizar Contraseña</h2>
+      <h2 id="change-title">Completar Registro</h2>
       <div class="login-fields">
+        <label for="primerNombre">Primer nombre</label>
+        <input type="text" id="primerNombre" required />
+
+        <label for="segundoNombre">Segundo nombre</label>
+        <input type="text" id="segundoNombre" />
+
+        <label for="primerApellido">Primer apellido</label>
+        <input type="text" id="primerApellido" required />
+
+        <label for="segundoApellido">Segundo apellido</label>
+        <input type="text" id="segundoApellido" />
+
+        <label for="email">Correo electrónico</label>
+        <input type="email" id="email" required />
+
+        <label for="celular">Celular</label>
+        <input type="text" id="celular" required />
+
         <label for="newPassword">Nueva contraseña</label>
         <div class="password-wrapper">
           <input type="password" id="newPassword" placeholder="Nueva contraseña" required />

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -46,21 +46,37 @@ exports.login = async (req, res) => {
 
 exports.changePassword = async (req, res) => {
     try {
-        const { newPassword } = req.body;
+        const {
+            newPassword,
+            primer_nombre,
+            segundo_nombre,
+            primer_apellido,
+            segundo_apellido,
+            email,
+            celular
+        } = req.body;
         const userId = req.user.id;
 
-        if (!newPassword) {
+        if (!primer_nombre || !primer_apellido || !email || !celular || !newPassword) {
             return res.status(400).json({
                 success: false,
-                message: 'Nueva contraseña requerida'
+                message: 'Datos incompletos'
             });
         }
 
-        await authService.cambiarContraseña(userId, newPassword);
-        res.json({ success: true, message: 'Contraseña actualizada correctamente' });
+        await authService.actualizarDatosIniciales(userId, {
+            newPassword,
+            primer_nombre,
+            segundo_nombre,
+            primer_apellido,
+            segundo_apellido,
+            email,
+            celular
+        });
+        res.json({ success: true, message: 'Datos actualizados correctamente' });
     } catch (error) {
         console.error('Error en changePassword:', error);
-        res.status(500).json({ success: false, message: 'Error al cambiar la contraseña' });
+        res.status(500).json({ success: false, message: 'Error al actualizar los datos' });
     }
 };
 

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -133,6 +133,29 @@ exports.cambiarContraseña = async (userId, newPassword) => {
     }
 };
 
+exports.actualizarDatosIniciales = async (userId, datos) => {
+    try {
+        const hashed = await bcrypt.hash(datos.newPassword, 10);
+        await db.query(
+            `UPDATE usuarios SET contraseña = ?, primer_nombre = ?, segundo_nombre = ?, primer_apellido = ?, segundo_apellido = ?, email = ?, celular = ?, ultimo_login = NOW(), intentos_fallidos = 0, bloqueado = FALSE, fecha_desbloqueo = NULL WHERE id = ?`,
+            [
+                hashed,
+                datos.primer_nombre,
+                datos.segundo_nombre || null,
+                datos.primer_apellido,
+                datos.segundo_apellido || null,
+                datos.email,
+                datos.celular,
+                userId
+            ]
+        );
+        return { success: true };
+    } catch (error) {
+        console.error('Error actualizando datos iniciales:', error);
+        throw error;
+    }
+};
+
 exports.logout = async (token, expiresAt) => {
     try {
         await db.query('INSERT INTO jwt_blacklist (token, expires_at) VALUES (?, ?)', [token, expiresAt]);


### PR DESCRIPTION
## Summary
- show additional fields on first login
- update frontend logic to send personal data and new password
- extend backend change-password endpoint to store this info

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1591a2483209804d925ebeded89