### PR TITLE
Add personal data consent in password setup

### DIFF
--- a/create_database.sql
+++ b/create_database.sql
@@ -34,6 +34,7 @@ CREATE TABLE usuarios (
   segundo_apellido VARCHAR(100),
   email VARCHAR(100),
   celular VARCHAR(20),
+  acepta_datos BOOLEAN DEFAULT FALSE,
   contraseña VARCHAR(255) NOT NULL,
   rol_id INT NOT NULL,
   activo BOOLEAN DEFAULT TRUE,

--- a/datos_iniciales.sql
+++ b/datos_iniciales.sql
@@ -2,17 +2,17 @@ use mesa_ayuda;
 
 INSERT INTO usuarios (
   tipo_documento_id, numero_documento, usuario, primer_nombre, segundo_nombre,
-  primer_apellido, segundo_apellido, email, celular, contraseña, rol_id
+  primer_apellido, segundo_apellido, email, celular, acepta_datos, contraseña, rol_id
 ) VALUES
-  (2, '200000002', 'admin2', 'María', 'José', 'Rodríguez', 'López', 'admin2@correo.com', '3000000001', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 1),
-  (1, '100000003', 'usuario_admin3', 'Andrés', 'Felipe', 'García', 'Torres', 'usuario_admin3@correo.com', '3000000002', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
-  (3, 'CE1234567', 'usuario_admin4', 'Paula', 'Andrea', 'Ramírez', 'Vargas', 'usuario_admin4@correo.com', '3000000003', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
-  (4, 'P7654321', 'usuario_admin5', 'Camila', NULL, 'Suárez', 'Mejía', 'usuario_admin5@correo.com', '3000000004', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
-  (1, '100000001', 'admin1', 'Carlos', 'Andrés', 'Pérez', 'Gómez', 'admin1@correo.com', '3000000005', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 1),
-  (4, 'P1234567', 'usuario_admin1', 'Luisa', NULL, 'Martínez', 'Díaz', 'usuario_admin1@correo.com', '3000000006', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
-  (3, 'CE9876543', 'usuario_admin2', 'Juan', 'Esteban', 'Córdoba', NULL, 'usuario_admin2@correo.com', '3000000007', '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
-  (4, 'P76543216', 'usuario1', 'María', 'Camila', 'Ruiz', 'Sánchez', 'usuario1@correo.com', '3000000008', '$2b$10$qg8YS80GD/imgBbuJfiYOOyVygtc6hYrKRr/aZqZrkL1O7.7b.yzS', 3),
-  (1, '100000005', 'usuario2', 'Diego', NULL, 'Fernández', 'López', 'usuario2@correo.com', '3000000009', '$2b$10$qg8YS80GD/imgBbuJfiYOOyVygtc6hYrKRr/aZqZrkL1O7.7b.yzS', 3);
+  (2, '200000002', 'admin2', 'María', 'José', 'Rodríguez', 'López', 'admin2@correo.com', '3000000001', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 1),
+  (1, '100000003', 'usuario_admin3', 'Andrés', 'Felipe', 'García', 'Torres', 'usuario_admin3@correo.com', '3000000002', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
+  (3, 'CE1234567', 'usuario_admin4', 'Paula', 'Andrea', 'Ramírez', 'Vargas', 'usuario_admin4@correo.com', '3000000003', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
+  (4, 'P7654321', 'usuario_admin5', 'Camila', NULL, 'Suárez', 'Mejía', 'usuario_admin5@correo.com', '3000000004', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
+  (1, '100000001', 'admin1', 'Carlos', 'Andrés', 'Pérez', 'Gómez', 'admin1@correo.com', '3000000005', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 1),
+  (4, 'P1234567', 'usuario_admin1', 'Luisa', NULL, 'Martínez', 'Díaz', 'usuario_admin1@correo.com', '3000000006', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
+  (3, 'CE9876543', 'usuario_admin2', 'Juan', 'Esteban', 'Córdoba', NULL, 'usuario_admin2@correo.com', '3000000007', 1, '$2b$10$VktcUyLyfUV8IteoBffHmeO.bOUaD0HM5X.ViS5IQqrJF7zcIAyzC', 2),
+  (4, 'P76543216', 'usuario1', 'María', 'Camila', 'Ruiz', 'Sánchez', 'usuario1@correo.com', '3000000008', 1, '$2b$10$qg8YS80GD/imgBbuJfiYOOyVygtc6hYrKRr/aZqZrkL1O7.7b.yzS', 3),
+  (1, '100000005', 'usuario2', 'Diego', NULL, 'Fernández', 'López', 'usuario2@correo.com', '3000000009', 1, '$2b$10$qg8YS80GD/imgBbuJfiYOOyVygtc6hYrKRr/aZqZrkL1O7.7b.yzS', 3);
 
 INSERT INTO categorias (id_area, id_prioridad, nombre, descripcion)
 VALUES

--- a/frontend/js/cambiar-contrasena.js
+++ b/frontend/js/cambiar-contrasena.js
@@ -8,10 +8,23 @@ const emailInput = document.getElementById('email');
 const celularInput = document.getElementById('celular');
 const newPasswordInput = document.getElementById('newPassword');
 const confirmPasswordInput = document.getElementById('confirmPassword');
+const aceptaDatosCheckbox = document.getElementById('aceptaDatos');
 const toggleNewPassword = document.getElementById('toggleNewPassword');
 const toggleConfirmPassword = document.getElementById('toggleConfirmPassword');
 const eyeOpen = '../public/assets/img/ojo-abierto.png';
 const eyeClosed = '../public/assets/img/ojo.png';
+
+btn.disabled = true;
+
+function updateButtonState() {
+    const requiredFilled = primerNombreInput.value.trim() && primerApellidoInput.value.trim() && emailInput.value.trim() && celularInput.value.trim() && newPasswordInput.value.trim() && confirmPasswordInput.value.trim();
+    btn.disabled = !(requiredFilled && aceptaDatosCheckbox.checked);
+}
+
+[primerNombreInput, primerApellidoInput, emailInput, celularInput, newPasswordInput, confirmPasswordInput].forEach(el => {
+    el.addEventListener('input', updateButtonState);
+});
+aceptaDatosCheckbox.addEventListener('change', updateButtonState);
 
 btn.addEventListener('click', async () => {
     const primer_nombre = primerNombreInput.value.trim();
@@ -22,8 +35,9 @@ btn.addEventListener('click', async () => {
     const celular = celularInput.value.trim();
     const newPassword = newPasswordInput.value.trim();
     const confirmPassword = confirmPasswordInput.value.trim();
+    const acepta_datos = aceptaDatosCheckbox.checked;
 
-    if (!primer_nombre || !primer_apellido || !email || !celular || !newPassword || !confirmPassword) {
+    if (!primer_nombre || !primer_apellido || !email || !celular || !newPassword || !confirmPassword || !acepta_datos) {
         showMessage('Por favor complete los campos obligatorios', 'error');
         return;
     }
@@ -54,7 +68,8 @@ btn.addEventListener('click', async () => {
                 primer_apellido,
                 segundo_apellido,
                 email,
-                celular
+                celular,
+                acepta_datos
             })
         });
         const data = await response.json();

--- a/frontend/views/cambiar-contrasena.html
+++ b/frontend/views/cambiar-contrasena.html
@@ -50,6 +50,11 @@
           </span>
         </div>
 
+        <div class="checkbox-container">
+          <input type="checkbox" id="aceptaDatos" required />
+          <label for="aceptaDatos" class="checkbox-label">Acepto el uso de mis datos personales según la Ley 1581 de 2012 y normas reglamentarias</label>
+        </div>
+
         <button id="changeBtn">Guardar</button>
         <p id="changeMessage" class="message"></p>
       </div>

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -53,11 +53,12 @@ exports.changePassword = async (req, res) => {
             primer_apellido,
             segundo_apellido,
             email,
-            celular
+            celular,
+            acepta_datos
         } = req.body;
         const userId = req.user.id;
 
-        if (!primer_nombre || !primer_apellido || !email || !celular || !newPassword) {
+        if (!primer_nombre || !primer_apellido || !email || !celular || !newPassword || !acepta_datos) {
             return res.status(400).json({
                 success: false,
                 message: 'Datos incompletos'
@@ -71,7 +72,8 @@ exports.changePassword = async (req, res) => {
             primer_apellido,
             segundo_apellido,
             email,
-            celular
+            celular,
+            acepta_datos
         });
         res.json({ success: true, message: 'Datos actualizados correctamente' });
     } catch (error) {

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -137,7 +137,7 @@ exports.actualizarDatosIniciales = async (userId, datos) => {
     try {
         const hashed = await bcrypt.hash(datos.newPassword, 10);
         await db.query(
-            `UPDATE usuarios SET contraseña = ?, primer_nombre = ?, segundo_nombre = ?, primer_apellido = ?, segundo_apellido = ?, email = ?, celular = ?, ultimo_login = NOW(), intentos_fallidos = 0, bloqueado = FALSE, fecha_desbloqueo = NULL WHERE id = ?`,
+            `UPDATE usuarios SET contraseña = ?, primer_nombre = ?, segundo_nombre = ?, primer_apellido = ?, segundo_apellido = ?, email = ?, celular = ?, acepta_datos = ?, ultimo_login = NOW(), intentos_fallidos = 0, bloqueado = FALSE, fecha_desbloqueo = NULL WHERE id = ?`,
             [
                 hashed,
                 datos.primer_nombre,
@@ -146,6 +146,7 @@ exports.actualizarDatosIniciales = async (userId, datos) => {
                 datos.segundo_apellido || null,
                 datos.email,
                 datos.celular,
+                datos.acepta_datos ? 1 : 0,
                 userId
             ]
         );


### PR DESCRIPTION
## Summary
- add `acepta_datos` column to usuarios table
- register default values for existing users
- require data policy consent when completing registration
- save consent via API when updating user info
- disable save button until mandatory fields and consent are filled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bca2adb308320a8563f08c95908fe