### PR TITLE
Handle missing params in dynamic view route

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const path = require('path');
 const bodyParser = require('body-parser');
+const fs = require('fs');
 
 const app = express();
 
@@ -96,6 +97,26 @@ try {
 // ✅ Ruta raíz (login)
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'frontend', 'views', 'login.html'));
+});
+
+// ✅ Cualquier otra vista HTML disponible en /frontend/views
+app.get('/:viewName.html', (req, res, next) => {
+  const viewName = req.params ? req.params.viewName : undefined;
+
+  if (!viewName) {
+    return next();
+  }
+
+  const sanitizedViewName = path.basename(viewName); // evita rutas con ../
+  const requestedViewPath = path.join(viewsPath, `${sanitizedViewName}.html`);
+
+  fs.access(requestedViewPath, fs.constants.F_OK, (err) => {
+    if (err) {
+      return next();
+    }
+
+    res.sendFile(requestedViewPath);
+  });
 });
 
 // 🩺 Ruta de salud


### PR DESCRIPTION
## Summary
- guard the dynamic HTML route when the request does not include a view parameter
- fall through to the next handler instead of throwing a destructuring error

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6904e3d9c1b4832082a060361df43871